### PR TITLE
fix hashbang

### DIFF
--- a/bin/phpactor
+++ b/bin/phpactor
@@ -1,3 +1,3 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 require('phpactor.php');


### PR DESCRIPTION
I have php 7.1 installed, and calling `./bin/phpactor` resulted in
```
Parse error: parse error, expecting `';'' or `'{'' in /....phpactor/vendor/dtl/class-to-file/lib/CompositeTransformer.php on line 16
```
which confused me for a while!

Fix this by using `#!/usr/bin/env php` that will use whatever php executable appears first in the user's `$PATH`